### PR TITLE
Box Controller Drag update handle

### DIFF
--- a/lib/src/flutter_sliding_box.dart
+++ b/lib/src/flutter_sliding_box.dart
@@ -988,6 +988,16 @@ class BoxController extends ValueNotifier<MenuIconValue> {
     _boxState = boxState;
   }
 
+  /// Handles when a new position is passed as a drag externally
+  void onDragUpdate(double dy) {
+    _boxState?._onGestureUpdate(dy);
+  }
+
+  /// Handles when drag end event is passed as a drag externally
+  void onDragEnd(Velocity v) {
+    _boxState?._onGestureEnd(v);
+  }
+
   /// Determine if the [SlidingBox.controller] is attached to an instance of the
   /// [SlidingBox] (this property must be true before any other [BoxController]
   /// functions can be used)


### PR DESCRIPTION
## Issue
I was working on my app which is a music app. As demonstrated in the example It opens the collapsed view by drag but when closing from the open state it was giving issue. This was because I gave the open height the full screen.

I then followed the example and tried to give 90% of the screen width. This gave me the access of some area above. I noticed that when I set draggableIconVisible as false on my opened body(panel) the drag was getting updated but it had some offset. Like the area just above it was used to drag the item down which was I suppose the area for the icon. I tried multiple ways, but maybe I was not able to dive deep enough to find a way if you have provided to it.

I gave a read to your source code and found a possible solution to it. I saw that there was a` _onGestureUpdate` and `_onGestureEnd` method which could be used in my case. I just exposed them with the help of BoxController and i was able to achieve the drag from externally. In my panel at the top I gave a inivisble Container of full width and height 40 and with that I was able to do the drag operation

Your source code is very readable and very well made thanks to that I was able to get to the solution very quickly.
I don't know if there is a solution to this but these few lines helped me and might help others.